### PR TITLE
adjust the parameters of the flippant.flip function for better control o...

### DIFF
--- a/flippant.js
+++ b/flippant.js
@@ -2,7 +2,7 @@
 return (function(e,t,n){function i(n,s){if(!t[n]){if(!e[n]){var o=typeof require=="function"&&require;if(!s&&o)return o(n,!0);if(r)return r(n,!0);throw new Error("Cannot find module '"+n+"'")}var u=t[n]={exports:{}};e[n][0].call(u.exports,function(t){var r=e[n][1][t];return i(r?r:t)},u,u.exports)}return t[n].exports}var r=typeof require=="function"&&require;for(var s=0;s<n.length;s++)i(n[s]);return i})({1:[function(require,module,exports){
 exports.flip = flip
 
-function flip(flipper, content, type, class_name, timeout) {
+function flip(flipper, back, type, class_name, timeout) {
   var position
     , back
     , style_func
@@ -21,10 +21,7 @@ function flip(flipper, content, type, class_name, timeout) {
     style_func = card_styles
   }
 
-  back = document.createElement('div')
-  document.body.appendChild(back)
   set_styles(back, flipper, position)
-  back.innerHTML = content
 
   flipper.classList.add('flippant')
   back.classList.add('flippant-back')
@@ -52,7 +49,6 @@ function flip(flipper, content, type, class_name, timeout) {
     flipper.classList.remove('flipped')
     window.setTimeout(function () {
       back.classList.remove(class_name)
-      document.body.removeChild(back)
     }, timeout)
   }
 


### PR DESCRIPTION
...ver the back element.

Changed the parameter `content` to the HTML element--that is the back of the card/modal--with the name `back`.

The older way was flawed in the sense that, when the `back` element was created, it was being appended to the `body` hence reducing the control over the flippand.

To better understand this, imagine a scenario where the developer wants to destroy the flipped card (i.e. the `back` element) when the user requests a new view (the Backbone-way). With the older way, it was incredibly hard to destroy the back element.

If the developer specifies the `back` element by himself (as this commit allows), s/he can destroy the container of the card/modals and will simply get rid of the overflowing back element whenever a new view is created.

Just a suggestion ;)
