### PR TITLE
make it able to flip with relative parents 

### DIFF
--- a/flippant.js
+++ b/flippant.js
@@ -61,8 +61,16 @@ function flip(flipper, content, type, class_name, timeout) {
 
 function set_styles(back, front, position) {
   back.style.position = position
-  back.style.top = front.offsetTop + "px"
-  back.style.left = front.offsetLeft + "px"
+  cur = front
+  totalLeft = 0
+  totalTop = 0
+  while (cur) {
+    totalLeft += cur.offsetLeft;
+    totalTop += cur.offsetTop;
+    cur = cur.offsetParent;
+  }
+  back.style.top = totalTop + "px"
+  back.style.left = totalLeft + "px"
   back.style['min-height'] = front.offsetHeight + "px"
   back.style.width = front.offsetWidth + "px"
   back.style["z-index"] = 9999


### PR DESCRIPTION
On my website, my front flippant got a parent div with "position:relative" and a margin-left, and it don't got the good positioning.

With this fix, flippant.js can flip it correctly, with the good offset.
